### PR TITLE
Refactor member deleting own account

### DIFF
--- a/src/__test__/routes/user/client/crud.test.ts
+++ b/src/__test__/routes/user/client/crud.test.ts
@@ -782,6 +782,7 @@ describe("CRUD CLIENT RESOURCE", () => {
           return expect(response.statusCode).toBe(401);
         }
       );
+
       test(
         `When an authenticated CLIENT accesses DELETE ${clientResourcePath}/:id ` +
           "in which the id is the client authenticated, then it should return a 204 status",

--- a/src/repositories/user/index.ts
+++ b/src/repositories/user/index.ts
@@ -257,8 +257,6 @@ export const deleteUser = async ({ id }: { id: string }) => {
     },
   });
 
-  console.log("hasClient = ", hasClient);
-
   if (hasClient && hasClient.addressId) {
     await prismaClient.address.update({
       where: {

--- a/src/routes/resources/user/member.ts
+++ b/src/routes/resources/user/member.ts
@@ -21,6 +21,7 @@ import { updateBodyMember } from "@middlewares/resources/user/member/updateBodyU
 import { Router } from "express";
 import {
   Schema,
+  body,
   checkExact,
   checkSchema,
   param,
@@ -156,7 +157,25 @@ memberRouter.put(
 );
 
 memberRouter.delete(
+  "/members/member/:userId",
+  validationAdminOrMemberAccessToken,
+  checkExact([
+    body([], "Body parameters unpermitted"),
+    query([], "Query parameters unpermitted"),
+    param(["userId"], "Router parameters unpermitted"),
+  ]),
+  validationParams,
+  validationUserOwnId,
+  deleteUserController
+);
+
+memberRouter.delete(
   "/members/:id",
+  checkExact([
+    body([], "Body parameters unpermitted"),
+    query([], "Query parameters unpermitted"),
+    param(["id"], "Router parameters unpermitted"),
+  ]),
   validationAdminOrClientAccessToken,
   deleteUserController
 );


### PR DESCRIPTION
If a member send the your own id in router DELETE /api/v1/resources/users/members/member/:userId, the user is deleted. However, if send the id of another user the 401 is returned